### PR TITLE
Add test coverage

### DIFF
--- a/lib/json_test_data/data_structures/helpers/number_helper.rb
+++ b/lib/json_test_data/data_structures/helpers/number_helper.rb
@@ -7,7 +7,7 @@ module JsonTestData
       adjust_for_maximum(number: num, maximum: maximum, step_size: step_size)
     end
 
-    def adjust_for_minimum(number:, minimum:, step_size: nil)
+    def adjust_for_minimum(number:, minimum: nil, step_size: nil)
       return number unless minimum && minimum >= number
 
       num = !!step_size ? number + step_size : minimum + 1

--- a/lib/json_test_data/data_structures/helpers/number_helper.rb
+++ b/lib/json_test_data/data_structures/helpers/number_helper.rb
@@ -15,7 +15,7 @@ module JsonTestData
     end
 
     def between(min:, max:, integer: false)
-      return integer ? mean(min, max).to_i : mean(min, max)
+      return integer ? mean(min, max).round(0) : mean(min, max)
     end
 
     def mean(*numbers)

--- a/lib/json_test_data/data_structures/helpers/number_helper.rb
+++ b/lib/json_test_data/data_structures/helpers/number_helper.rb
@@ -21,9 +21,5 @@ module JsonTestData
     def mean(*numbers)
       numbers.inject(:+).to_f.quo(numbers.length)
     end
-
-    def infinity
-      Math.atanh(1)
-    end
   end
 end

--- a/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
+++ b/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
@@ -134,4 +134,13 @@ describe JsonTestData::NumberHelper do
       end
     end
   end
+
+  describe "#mean" do
+    let(:numbers) { [ 3, 4, 5, 6 ] }
+    let(:avg) { 4.5 }
+
+    it "returns the mean" do
+      expect(mean(*numbers)).to be_within(0.0002).of(avg)
+    end
+  end
 end

--- a/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
+++ b/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
@@ -11,9 +11,21 @@ describe JsonTestData::NumberHelper do
     end
 
     context "number less than maximum" do
+      let(:number) { 3 }
+      let(:maximum) { 4 }
+
+      it "returns the given number" do
+        expect(adjust_for_maximum(number: number, maximum: maximum)).to eql number
+      end
     end
 
     context "number greater than or equal to maximum" do
+      let(:number) { 3 }
+      let(:maximum) { 3 }
+
+      it "returns one less than the maximum" do
+        expect(adjust_for_maximum(number: number, maximum: maximum)).to eql maximum - 1
+      end
     end
   end
 end

--- a/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
+++ b/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
@@ -123,5 +123,15 @@ describe JsonTestData::NumberHelper do
         expect(between(min: min, max: max)).to be_greater_than(min)
       end
     end
+
+    context "when it has to be an integer" do
+      let(:min) { 2 }
+      let(:max) { 5 }
+      let(:result) { 3 }
+
+      it "returns the nearest integer" do
+        expect(between(min: min, max: max, integer: true)).to eql result
+      end
+    end
   end
 end

--- a/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
+++ b/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
@@ -1,0 +1,19 @@
+describe JsonTestData::NumberHelper do
+  include JsonTestData::NumberHelper
+
+  describe "#adjust_for_maximum" do
+    context "no maximum" do
+      let(:number) { 3 }
+
+      it "returns the given number" do
+        expect(adjust_for_maximum(number: number)).to eql number
+      end
+    end
+
+    context "number less than maximum" do
+    end
+
+    context "number greater than or equal to maximum" do
+    end
+  end
+end

--- a/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
+++ b/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
@@ -104,4 +104,24 @@ describe JsonTestData::NumberHelper do
       end
     end
   end
+
+  describe "#between" do
+    context "when it doesn't have to be an integer" do
+      let(:min) { 1 }
+      let(:max) { 2 }
+      let(:result) { 1.5 }
+
+      it "returns the mean" do
+        expect(between(min: min, max: max)).to be_within(0.0002).of(result)
+      end
+
+      it "is less than the max" do
+        expect(between(min: min, max: max)).to be_less_than(max)
+      end
+
+      it "is greater than the min" do
+        expect(between(min: min, max: max)).to be_greater_than(min)
+      end
+    end
+  end
 end

--- a/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
+++ b/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
@@ -39,5 +39,17 @@ describe JsonTestData::NumberHelper do
         ).to eql number - step_size
       end
     end
+
+    context "step size less than 1" do
+      let(:number) { 3 }
+      let(:maximum) { 3 }
+      let(:step_size) { 0.25 }
+
+      it "returns the number reduced by step size" do
+        expect(
+          adjust_for_maximum(number: number, maximum: maximum, step_size: step_size)
+        ).to eql number - step_size
+      end
+    end
   end
 end

--- a/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
+++ b/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
@@ -61,5 +61,14 @@ describe JsonTestData::NumberHelper do
         expect(adjust_for_minimum(number: number)).to eql number
       end
     end
+
+    context "number is greater than minimum" do
+      let(:number) { 1 }
+      let(:minimum) { 0 }
+
+      it "returns the number" do
+        expect(adjust_for_minimum(number: number, minimum: minimum)).to eql number
+      end
+    end
   end
 end

--- a/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
+++ b/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
@@ -27,5 +27,17 @@ describe JsonTestData::NumberHelper do
         expect(adjust_for_maximum(number: number, maximum: maximum)).to eql maximum - 1
       end
     end
+
+    context "step size greater than 1" do
+      let(:number) { 3 }
+      let(:maximum) { 3 }
+      let(:step_size) { 2 }
+
+      it "returns the number reduced by step size" do
+        expect(
+          adjust_for_maximum(number: number, maximum: maximum, step_size: step_size)
+        ).to eql number - step_size
+      end
+    end
   end
 end

--- a/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
+++ b/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
@@ -36,7 +36,7 @@ describe JsonTestData::NumberHelper do
       it "returns the number reduced by step size" do
         expect(
           adjust_for_maximum(number: number, maximum: maximum, step_size: step_size)
-        ).to eql number - step_size
+        ).to eql maximum - step_size
       end
     end
 
@@ -48,7 +48,7 @@ describe JsonTestData::NumberHelper do
       it "returns the number reduced by step size" do
         expect(
           adjust_for_maximum(number: number, maximum: maximum, step_size: step_size)
-        ).to eql number - step_size
+        ).to eql maximum - step_size
       end
     end
   end
@@ -68,6 +68,39 @@ describe JsonTestData::NumberHelper do
 
       it "returns the number" do
         expect(adjust_for_minimum(number: number, minimum: minimum)).to eql number
+      end
+    end
+
+    context "number is less than or equal to minimum" do
+      let(:number) { 2 }
+      let(:minimum) { 2 }
+
+      it "returns one more than the minimum" do
+        expect(adjust_for_minimum(number: number, minimum: minimum)).to eql minimum + 1
+      end
+    end
+
+    context "step size greater than 1" do
+      let(:number) { 2 }
+      let(:minimum) { 2 }
+      let(:step_size) { 2 }
+
+      it "returns the number increased by step size" do
+        expect(
+          adjust_for_minimum(number: number, minimum: minimum, step_size: step_size)
+        ).to eql minimum + step_size
+      end
+    end
+
+    context "step size less than 1" do
+      let(:number) { 2 }
+      let(:minimum) { 2 }
+      let(:step_size) { 0.5 }
+
+      it "returns the number reduced by step size" do
+        expect(
+          adjust_for_minimum(number: number, minimum: minimum, step_size: step_size)
+        ).to eql minimum + step_size
       end
     end
   end

--- a/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
+++ b/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
@@ -127,7 +127,7 @@ describe JsonTestData::NumberHelper do
     context "when it has to be an integer" do
       let(:min) { 2 }
       let(:max) { 5 }
-      let(:result) { 3 }
+      let(:result) { 4 }
 
       it "returns the nearest integer" do
         expect(between(min: min, max: max, integer: true)).to eql result

--- a/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
+++ b/spec/json_test_data/data_structures/helpers/number_helper_spec.rb
@@ -52,4 +52,14 @@ describe JsonTestData::NumberHelper do
       end
     end
   end
+
+  describe "#adjust_for_minimum" do
+    context "no minimum" do
+      let(:number) { 1 }
+
+      it "returns the given number" do
+        expect(adjust_for_minimum(number: number)).to eql number
+      end
+    end
+  end
 end

--- a/spec/matchers/number_matchers.rb
+++ b/spec/matchers/number_matchers.rb
@@ -12,6 +12,12 @@ RSpec::Matchers.define :be_greater_than do |expected|
   end
 end
 
+RSpec::Matchers.define :be_less_than do |expected|
+  match do |actual|
+    actual < expected
+  end
+end
+
 RSpec::Matchers.define :be_less_than_or_equal_to do |expected|
   match do |actual|
     actual <= expected


### PR DESCRIPTION
This PR adds test coverage for the NumberHelper module, deletes an unused method, and modifies the `NumberHelper::between` method to use `round(0)` to convert to an integer instead of `to_i`, which truncates.