### PR TITLE
Add :ruby option

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json_test_data (0.3.0.beta)
+    json_test_data (0.4.0.beta)
       regxing (~> 0.1.0.beta)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ To use it, first require it, then generate the test data using:
 ```ruby
 data = JsonTestData.generate!(schema)
 ```
+If you would prefer to return a Ruby object instead of a JSON object, simply include the `:ruby` option:
+```ruby
+data = JsonTestData.generate!(schema, ruby: true)
+```
 
 The input that you put into it must be valid [JSON schema](http://json-schema.org). The top-level object must have a `:type` key indicating the type of object to be generated ("object", "array", "string", etc.).
 

--- a/features/generate_empty_objects.feature
+++ b/features/generate_empty_objects.feature
@@ -28,3 +28,28 @@ Feature: Generating empty objects
       """json
       [null]
       """
+
+  Scenario: Ruby hash
+    Given the following JSON schema:
+      """json
+      {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {}
+      }
+      """
+    When I run the JSON data generator with the "ruby" option
+    Then the output should be a Ruby hash
+
+
+  Scenario: Ruby array
+    Given the following JSON schema:
+      """json
+      {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "array",
+        "items": {}
+      }
+      """
+    When I run the JSON data generator with the "ruby" option
+    Then the output should be a Ruby array

--- a/features/step_definitions/json_test_data_steps.rb
+++ b/features/step_definitions/json_test_data_steps.rb
@@ -6,8 +6,20 @@ When(/^I run the JSON data generator$/) do
   @output = JsonTestData.generate!(@schema)
 end
 
+When(/^I run the JSON data generator with the "ruby" option$/) do
+  @output = JsonTestData.generate!(@schema, ruby: true)
+end
+
 Then(/^the JSON output should be:$/) do |json|
   expect(@output).to eq json
+end
+
+Then(/^the output should be a Ruby hash$/) do
+  expect(@output).to be_a(Hash)
+end
+
+Then(/^the output should be a Ruby array$/) do
+  expect(@output).to be_a(Array)
 end
 
 Then(/^the "([^" ]*)" property of the JSON output should be a ([^ ]*)$/) do |prop, type|

--- a/lib/json_test_data.rb
+++ b/lib/json_test_data.rb
@@ -4,7 +4,8 @@ require 'regxing'
 require_relative './json_test_data/json_schema'
 
 module JsonTestData
-  def self.generate!(schema)
-    JsonSchema.new(schema).generate_example
+  def self.generate!(schema, opts={})
+    schema = JsonSchema.new(schema).generate_example
+    opts[:ruby] ? JSON.parse(schema) : schema
   end
 end

--- a/version.rb
+++ b/version.rb
@@ -1,3 +1,3 @@
 module JsonTestData
-  VERSION = '0.3.0.beta'
+  VERSION = '0.4.0.beta'
 end


### PR DESCRIPTION
This PR adds functionality to enable users to generate a Ruby object instead of a JSON object using the `:ruby` option.
```ruby
JsonTestData.generate!(schema, ruby: true)
```