### PR TITLE
Symbolize keys in Ruby hashes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json_test_data (0.4.0)
+    json_test_data (0.5.0)
       regxing (~> 0.1.0.beta)
 
 GEM

--- a/lib/json_test_data.rb
+++ b/lib/json_test_data.rb
@@ -6,6 +6,6 @@ require_relative './json_test_data/json_schema'
 module JsonTestData
   def self.generate!(schema, opts={})
     schema = JsonSchema.new(schema).generate_example
-    opts[:ruby] ? JSON.parse(schema) : schema
+    opts[:ruby] ? JSON.parse(schema, symbolize_names: true) : schema
   end
 end

--- a/version.rb
+++ b/version.rb
@@ -1,3 +1,3 @@
 module JsonTestData
-  VERSION = '0.4.0'
+  VERSION = '0.5.0'
 end


### PR DESCRIPTION
When the `:ruby` option is used, any hashes should have symbols, not strings, as keys.