### PR TITLE
Handle the enum property for strings

### DIFF
--- a/features/string_constraints.feature
+++ b/features/string_constraints.feature
@@ -32,3 +32,24 @@ Feature: String constraints
       """
     When I run the JSON data generator
     Then the output should match the schema
+
+  Scenario: Possible values given
+    Given the following JSON schema:
+      """json
+      {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "enum": [
+              "foo",
+              "bar",
+              "baz"
+            ]
+          }
+        }
+      }
+      """
+    When I run the JSON data generator
+    Then the output should match the schema

--- a/lib/json_test_data/data_structures/string.rb
+++ b/lib/json_test_data/data_structures/string.rb
@@ -4,6 +4,7 @@ module JsonTestData
 
     class << self
       def create(schema)
+        return schema.fetch(:enum).sample if schema.fetch(:enum, nil)
         len = schema.fetch(:maxLength, nil) || schema.fetch(:minLength, nil) || 1
         Generator.new(/.{#{len}}/).generate!
       end

--- a/spec/json_test_data/data_structures/string_spec.rb
+++ b/spec/json_test_data/data_structures/string_spec.rb
@@ -41,5 +41,20 @@ describe JsonTestData::String do
         expect(described_class.create(object).length).to eq 8
       end
     end
+
+    context "with enum" do
+      let(:enum) { ["foo", "bar", "baz"] }
+
+      let(:object) do
+        {
+          type: "string",
+          enum: enum
+        }
+      end
+
+      it "returns a string from the list" do
+        expect(described_class.create(object)).to be_in enum
+      end
+    end
   end
 end

--- a/spec/matchers/array_matchers.rb
+++ b/spec/matchers/array_matchers.rb
@@ -1,0 +1,7 @@
+require "rspec/expectations"
+
+RSpec::Matchers.define :be_in do |expected|
+  match do |actual|
+    expected.include?(actual)
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,6 +8,7 @@ require_relative "../lib/json_test_data/data_structures/string"
 require_relative "../lib/json_test_data/data_structures/number"
 require_relative "./matchers/number_matchers"
 require_relative "./matchers/json_schema_matchers"
+require_relative "./matchers/array_matchers"
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
JSON Schema allows an `"enum"` property to be used to validate strings, where `"enum"` is an array of possible string values. This PR adds functionality to select randomly from the given array and use the chosen value for the string in question.