### PR TITLE
Replace RegXing

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     json_test_data (0.8.0)
-      regxing (~> 0.1.0)
+      regexp-examples (~> 1.2)
 
 GEM
   remote: https://rubygems.org/
@@ -41,7 +41,7 @@ GEM
       method_source (~> 0.8.1)
       slop (~> 3.4)
     rake (11.1.2)
-    regxing (0.1.0)
+    regexp-examples (1.2.1)
     rspec (3.4.0)
       rspec-core (~> 3.4.0)
       rspec-expectations (~> 3.4.0)

--- a/json_test_data.gemspec
+++ b/json_test_data.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.platform              = Gem::Platform::RUBY
   s.required_ruby_version = ">= 2.1.0"
 
-  s.add_dependency "regxing", "~> 0.1.0"
+  s.add_dependency "regexp-examples", "~> 1.2"
 
   s.add_development_dependency "cucumber", "~> 2.1"
   s.add_development_dependency "rspec", "~> 3.4"

--- a/lib/json_test_data.rb
+++ b/lib/json_test_data.rb
@@ -1,5 +1,5 @@
 require 'json'
-require 'regxing'
+require 'regexp-examples'
 
 require_relative './json_test_data/json_schema'
 

--- a/lib/json_test_data/data_structures/string.rb
+++ b/lib/json_test_data/data_structures/string.rb
@@ -5,7 +5,7 @@ module JsonTestData
         return schema.fetch(:enum).sample if schema.fetch(:enum, nil)
 
         len = schema.fetch(:maxLength, nil) || schema.fetch(:minLength, nil) || 1
-        RegXing::Generator.new(/.{#{len}}/).generate!
+        /.{#{len}}/.random_example
       end
     end
   end


### PR DESCRIPTION
This PR removes RegXing as a dependency of JSON Test Data and replaces it with the [`regexp-examples` gem](https://github.com/tom-lord/regexp-examples).