### PR TITLE
Handle oneOf property

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json_test_data (0.9.0)
+    json_test_data (1.0.0)
       regexp-examples (~> 1.2)
 
 GEM

--- a/features/conditional_properties.feature
+++ b/features/conditional_properties.feature
@@ -12,43 +12,47 @@ Feature: Assign values conditionally
         ],
         "definitions": {
           "californiaAddress": {
-            "street": { "type": "string" },
-            "city": {
-              "type": "string",
-              "enum": [
-                "San Diego",
-                "Los Angeles",
-                "San Francisco",
-                "Sacramento"
-              ]
-            },
-            "state": {
-              "type": "string",
-              "enum": [ "CA" ]
-            },
-            "zip": {
-              "type": "string",
-              "pattern": "\\d{5}"
+            "properties": {
+              "street": { "type": "string" },
+              "city": {
+                "type": "string",
+                "enum": [
+                  "San Diego",
+                  "Los Angeles",
+                  "San Francisco",
+                  "Sacramento"
+                ]
+              },
+              "state": {
+                "type": "string",
+                "enum": [ "CA" ]
+              },
+              "zip": {
+                "type": "string",
+                "pattern": "\\d{5}"
+              }
             }
           },
           "floridaAddress": {
-            "street": { "type": "string" },
-            "city": {
-              "type": "string",
-              "enum": [
-                "Miami",
-                "Orlando",
-                "St. Petersburg",
-                "Tampa",
-                "Fort Lauderdale",
-                "Tallahassee",
-                "Hialeah",
-                "Jacksonville"
-              ]
-            },
-            "state": {
-              "type": "string",
-              "enum": [ "FL" ]
+            "properties": {
+              "street": { "type": "string" },
+              "city": {
+                "type": "string",
+                "enum": [
+                  "Miami",
+                  "Orlando",
+                  "St. Petersburg",
+                  "Tampa",
+                  "Fort Lauderdale",
+                  "Tallahassee",
+                  "Hialeah",
+                  "Jacksonville"
+                ]
+              },
+              "state": {
+                "type": "string",
+                "enum": [ "FL" ]
+              }
             }
           }
         }

--- a/features/conditional_properties.feature
+++ b/features/conditional_properties.feature
@@ -7,44 +7,56 @@ Feature: Assign values conditionally
         "$schema": "http://json-schema.org/draft-04/schema#",
         "type": "object",
         "oneOf": [
-          { "$ref": "#/definitions/californiaAddress" },
-          { "$ref": "#/definitions/floridaAddress"}
+          { "$rel": "#/definitions/californiaAddress" },
+          { "$rel": "#/definitions/floridaAddress"}
         ],
         "definitions": {
           "californiaAddress": {
-            "street": { "type": "string" },
-            "city": {
-              "type": "string",
-              "enum": [
-                "San Diego",
-                "Los Angeles",
-                "San Francisco",
-                "Sacramento"
-              ],
+            "properties": {
+              "street": { "type": "string" },
+              "city": {
+                "type": "string",
+                "enum": [
+                  "San Diego",
+                  "Los Angeles",
+                  "San Francisco",
+                  "Sacramento"
+                ]
+              },
               "state": {
                 "type": "string",
                 "enum": [ "CA" ]
               },
               "zip": {
                 "type": "string",
-                "pattern": "\d{5}"
+                "pattern": "\\d{5}"
               }
             }
           },
           "floridaAddress": {
-            "street": { "type": "string" },
-            "city": {
-              "type": "string",
-              "enum": [
-                "Miami",
-                "Orlando",
-                "St. Petersburg",
-                "Tampa",
-                "Fort Lauderdale",
-                "Tallahassee",
-                "Hialeah",
-                "Jacksonville"
-              ]
+            "properties": {
+              "street": { "type": "string" },
+              "city": {
+                "type": "string",
+                "enum": [
+                  "Miami",
+                  "Orlando",
+                  "St. Petersburg",
+                  "Tampa",
+                  "Fort Lauderdale",
+                  "Tallahassee",
+                  "Hialeah",
+                  "Jacksonville"
+                ]
+              },
+              "state": {
+                "type": "string",
+                "enum": [ "FL" ]
+              },
+              "zip": {
+                "type": "string",
+                "pattern": "\\d{5}"
+              }
             }
           }
         }

--- a/features/conditional_properties.feature
+++ b/features/conditional_properties.feature
@@ -1,0 +1,54 @@
+Feature: Assign values conditionally
+
+  Scenario: Values depend on another property
+    Given the following JSON schema:
+      """
+      {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "oneOf": [
+          { "$ref": "#/definitions/californiaAddress" },
+          { "$ref": "#/definitions/floridaAddress"}
+        ],
+        "definitions": {
+          "californiaAddress": {
+            "street": { "type": "string" },
+            "city": {
+              "type": "string",
+              "enum": [
+                "San Diego",
+                "Los Angeles",
+                "San Francisco",
+                "Sacramento"
+              ],
+              "state": {
+                "type": "string",
+                "enum": [ "CA" ]
+              },
+              "zip": {
+                "type": "string",
+                "pattern": "\d{5}"
+              }
+            }
+          },
+          "floridaAddress": {
+            "street": { "type": "string" },
+            "city": {
+              "type": "string",
+              "enum": [
+                "Miami",
+                "Orlando",
+                "St. Petersburg",
+                "Tampa",
+                "Fort Lauderdale",
+                "Tallahassee",
+                "Hialeah",
+                "Jacksonville"
+              ]
+            }
+          }
+        }
+      }
+      """
+    When I run the JSON data generator
+    Then the output should match the schema

--- a/features/conditional_properties.feature
+++ b/features/conditional_properties.feature
@@ -7,56 +7,44 @@ Feature: Assign values conditionally
         "$schema": "http://json-schema.org/draft-04/schema#",
         "type": "object",
         "oneOf": [
-          { "$rel": "#/definitions/californiaAddress" },
-          { "$rel": "#/definitions/floridaAddress"}
+          { "$ref": "#/definitions/californiaAddress" },
+          { "$ref": "#/definitions/floridaAddress"}
         ],
         "definitions": {
           "californiaAddress": {
-            "properties": {
-              "street": { "type": "string" },
-              "city": {
-                "type": "string",
-                "enum": [
-                  "San Diego",
-                  "Los Angeles",
-                  "San Francisco",
-                  "Sacramento"
-                ]
-              },
+            "street": { "type": "string" },
+            "city": {
+              "type": "string",
+              "enum": [
+                "San Diego",
+                "Los Angeles",
+                "San Francisco",
+                "Sacramento"
+              ],
               "state": {
                 "type": "string",
                 "enum": [ "CA" ]
               },
               "zip": {
                 "type": "string",
-                "pattern": "\\d{5}"
+                "pattern": "\d{5}"
               }
             }
           },
           "floridaAddress": {
-            "properties": {
-              "street": { "type": "string" },
-              "city": {
-                "type": "string",
-                "enum": [
-                  "Miami",
-                  "Orlando",
-                  "St. Petersburg",
-                  "Tampa",
-                  "Fort Lauderdale",
-                  "Tallahassee",
-                  "Hialeah",
-                  "Jacksonville"
-                ]
-              },
-              "state": {
-                "type": "string",
-                "enum": [ "FL" ]
-              },
-              "zip": {
-                "type": "string",
-                "pattern": "\\d{5}"
-              }
+            "street": { "type": "string" },
+            "city": {
+              "type": "string",
+              "enum": [
+                "Miami",
+                "Orlando",
+                "St. Petersburg",
+                "Tampa",
+                "Fort Lauderdale",
+                "Tallahassee",
+                "Hialeah",
+                "Jacksonville"
+              ]
             }
           }
         }

--- a/features/conditional_properties.feature
+++ b/features/conditional_properties.feature
@@ -12,6 +12,7 @@ Feature: Assign values conditionally
         ],
         "definitions": {
           "californiaAddress": {
+            "required": [ "street", "city", "state", "zip" ],
             "properties": {
               "street": { "type": "string" },
               "city": {
@@ -34,6 +35,7 @@ Feature: Assign values conditionally
             }
           },
           "floridaAddress": {
+            "required": [ "street", "city", "state" ],
             "properties": {
               "street": { "type": "string" },
               "city": {

--- a/features/conditional_properties.feature
+++ b/features/conditional_properties.feature
@@ -1,6 +1,32 @@
 Feature: Assign values conditionally
+  Scenario: Multiple schemas inline
+    Given the following JSON schema:
+      """
+      {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "oneOf": [
+          {
+            "required": [ "foo", "bar" ],
+            "properties": {
+              "foo": { "type": "string" },
+              "bar": { "type": "integer" }
+            }
+          },
+          {
+            "required": [ "baz", "qux" ],
+            "properties": {
+              "baz": { "type": "string" },
+              "qux": { "type": "string" }
+            }
+          }
+        ]
+      }
+      """
+    When I run the JSON data generator
+    Then the output should match the schema
 
-  Scenario: Values depend on another property
+  Scenario: Multiple schemas with refs
     Given the following JSON schema:
       """
       {

--- a/features/conditional_properties.feature
+++ b/features/conditional_properties.feature
@@ -7,8 +7,8 @@ Feature: Assign values conditionally
         "$schema": "http://json-schema.org/draft-04/schema#",
         "type": "object",
         "oneOf": [
-          { "$ref": "#/definitions/californiaAddress" },
-          { "$ref": "#/definitions/floridaAddress"}
+          { "$rel": "#/definitions/californiaAddress" },
+          { "$rel": "#/definitions/floridaAddress"}
         ],
         "definitions": {
           "californiaAddress": {
@@ -20,15 +20,15 @@ Feature: Assign values conditionally
                 "Los Angeles",
                 "San Francisco",
                 "Sacramento"
-              ],
-              "state": {
-                "type": "string",
-                "enum": [ "CA" ]
-              },
-              "zip": {
-                "type": "string",
-                "pattern": "\d{5}"
-              }
+              ]
+            },
+            "state": {
+              "type": "string",
+              "enum": [ "CA" ]
+            },
+            "zip": {
+              "type": "string",
+              "pattern": "\\d{5}"
             }
           },
           "floridaAddress": {
@@ -45,6 +45,10 @@ Feature: Assign values conditionally
                 "Hialeah",
                 "Jacksonville"
               ]
+            },
+            "state": {
+              "type": "string",
+              "enum": [ "FL" ]
             }
           }
         }

--- a/features/conditional_properties.feature
+++ b/features/conditional_properties.feature
@@ -7,48 +7,34 @@ Feature: Assign values conditionally
         "$schema": "http://json-schema.org/draft-04/schema#",
         "type": "object",
         "oneOf": [
-          { "$rel": "#/definitions/californiaAddress" },
-          { "$rel": "#/definitions/floridaAddress"}
+          { "$ref": "#/definitions/californiaAddress" },
+          { "$ref": "#/definitions/floridaAddress"}
         ],
         "definitions": {
           "californiaAddress": {
-            "required": [ "street", "city", "state", "zip" ],
+            "required": [ "city", "state" ],
             "properties": {
-              "street": { "type": "string" },
               "city": {
                 "type": "string",
                 "enum": [
                   "San Diego",
-                  "Los Angeles",
-                  "San Francisco",
-                  "Sacramento"
+                  "Los Angeles"
                 ]
               },
               "state": {
                 "type": "string",
                 "enum": [ "CA" ]
-              },
-              "zip": {
-                "type": "string",
-                "pattern": "\\d{5}"
               }
             }
           },
           "floridaAddress": {
-            "required": [ "street", "city", "state" ],
+            "required": [ "city", "state" ],
             "properties": {
-              "street": { "type": "string" },
               "city": {
                 "type": "string",
                 "enum": [
                   "Miami",
-                  "Orlando",
-                  "St. Petersburg",
-                  "Tampa",
-                  "Fort Lauderdale",
-                  "Tallahassee",
-                  "Hialeah",
-                  "Jacksonville"
+                  "Orlando"
                 ]
               },
               "state": {

--- a/lib/json_test_data.rb
+++ b/lib/json_test_data.rb
@@ -1,7 +1,7 @@
-require 'json'
-require 'regexp-examples'
+require "json"
+require "regexp-examples"
 
-require_relative './json_test_data/json_schema'
+require_relative "./json_test_data/json_schema"
 
 module JsonTestData
   def self.generate!(schema, opts={})

--- a/lib/json_test_data/data_structures/string.rb
+++ b/lib/json_test_data/data_structures/string.rb
@@ -3,6 +3,7 @@ module JsonTestData
     class << self
       def create(schema)
         return schema.fetch(:enum).sample if schema.fetch(:enum, nil)
+
         pattern(schema).random_example
       end
 

--- a/lib/json_test_data/data_structures/string.rb
+++ b/lib/json_test_data/data_structures/string.rb
@@ -3,7 +3,6 @@ module JsonTestData
     class << self
       def create(schema)
         return schema.fetch(:enum).sample if schema.fetch(:enum, nil)
-
         pattern(schema).random_example
       end
 

--- a/lib/json_test_data/json_schema.rb
+++ b/lib/json_test_data/json_schema.rb
@@ -45,8 +45,19 @@ module JsonTestData
         property.fetch(:type, nil) == "array"
       end
 
+      def resolve_rel(object, rel)
+        rel = rel.split("/").map(&:to_sym)[1..-1]
+        rel.each {|key| object = object.fetch(key) }
+        object
+      end
+
       def generate_object(object)
         obj = {}
+
+        if object.has_key?(:oneOf)
+          schema_to_be_used = object.fetch(:oneOf).sample
+          object = resolve_rel(object, schema_to_be_used.fetch(:"$rel"))
+        end
 
         if object.has_key?(:properties)
           object.fetch(:properties).each do |k, v|

--- a/lib/json_test_data/json_schema.rb
+++ b/lib/json_test_data/json_schema.rb
@@ -51,16 +51,16 @@ module JsonTestData
         object
       end
 
+      def set_object(obj, schema)
+        schema.has_key?(:"$ref") ? resolve_ref(obj, schema.fetch(:"$ref")) : schema
+      end
+
       def generate_object(object)
         obj = {}
 
         if object.has_key?(:oneOf)
           schema_to_be_used = object.fetch(:oneOf).sample
-          object = if schema_to_be_used.fetch(:"$ref", nil)
-                     resolve_ref(object, schema_to_be_used.fetch(:"$ref"))
-                   else
-                     schema_to_be_used
-                   end
+          object = set_object(object, schema_to_be_used)
         end
 
         if object.has_key?(:properties)

--- a/lib/json_test_data/json_schema.rb
+++ b/lib/json_test_data/json_schema.rb
@@ -45,9 +45,9 @@ module JsonTestData
         property.fetch(:type, nil) == "array"
       end
 
-      def resolve_rel(object, rel)
-        rel = rel.split("/").map(&:to_sym)[1..-1]
-        rel.each {|key| object = object.fetch(key) }
+      def resolve_ref(object, ref)
+        ref = ref.split("/").map(&:to_sym)[1..-1]
+        ref.each {|key| object = object.fetch(key) }
         object
       end
 
@@ -56,7 +56,7 @@ module JsonTestData
 
         if object.has_key?(:oneOf)
           schema_to_be_used = object.fetch(:oneOf).sample
-          object = resolve_rel(object, schema_to_be_used.fetch(:"$rel"))
+          object = resolve_ref(object, schema_to_be_used.fetch(:"$ref"))
         end
 
         if object.has_key?(:properties)

--- a/lib/json_test_data/json_schema.rb
+++ b/lib/json_test_data/json_schema.rb
@@ -56,7 +56,11 @@ module JsonTestData
 
         if object.has_key?(:oneOf)
           schema_to_be_used = object.fetch(:oneOf).sample
-          object = resolve_ref(object, schema_to_be_used.fetch(:"$ref"))
+          object = if schema_to_be_used.fetch(:"$ref", nil)
+                     resolve_ref(object, schema_to_be_used.fetch(:"$ref"))
+                   else
+                     schema_to_be_used
+                   end
         end
 
         if object.has_key?(:properties)

--- a/spec/json_test_data/json_schema_spec.rb
+++ b/spec/json_test_data/json_schema_spec.rb
@@ -113,8 +113,8 @@ describe JsonTestData::JsonSchema do
           :"$schema" => "http://json-schema.org/draft-04/schema#",
           :type      => "object",
           :oneOf     => [
-            { :"$rel" => "#/definitions/foo" },
-            { :"$rel" => "#/definitions/bar" }
+            { :"$ref" => "#/definitions/foo" },
+            { :"$ref" => "#/definitions/bar" }
           ],
           :definitions => {
             :foo => {

--- a/spec/json_test_data/json_schema_spec.rb
+++ b/spec/json_test_data/json_schema_spec.rb
@@ -119,6 +119,7 @@ describe JsonTestData::JsonSchema do
           :definitions => {
             :foo => {
               :type => "object",
+              :required => [ "name", "age" ],
               :properties => {
                 :name => { :type => "string", :enum => [ "Foo" ] },
                 :age => { :type => "integer" }
@@ -126,6 +127,7 @@ describe JsonTestData::JsonSchema do
             },
             :bar => {
               :type => "object",
+              :required => [ "first_name", "last_name" ],
               :properties => {
                 :first_name => { :type => "string", :enum => [ "Bar" ] },
                 :last_name => { :type => "string" }

--- a/spec/json_test_data/json_schema_spec.rb
+++ b/spec/json_test_data/json_schema_spec.rb
@@ -119,7 +119,6 @@ describe JsonTestData::JsonSchema do
           :definitions => {
             :foo => {
               :type => "object",
-              :required => [ "name", "age" ],
               :properties => {
                 :name => { :type => "string", :enum => [ "Foo" ] },
                 :age => { :type => "integer" }
@@ -127,7 +126,6 @@ describe JsonTestData::JsonSchema do
             },
             :bar => {
               :type => "object",
-              :required => [ "first_name", "last_name" ],
               :properties => {
                 :first_name => { :type => "string", :enum => [ "Bar" ] },
                 :last_name => { :type => "string" }

--- a/spec/json_test_data/json_schema_spec.rb
+++ b/spec/json_test_data/json_schema_spec.rb
@@ -60,7 +60,6 @@ describe JsonTestData::JsonSchema do
 
     describe "bigger examples" do
       context "when schema describes an object" do
-
         let(:schema) do
           {
             :"$schema"  => "http://json-schema.org/draft-04/schema#",
@@ -105,6 +104,67 @@ describe JsonTestData::JsonSchema do
           all_numbers = array.all? {|item| item.is_a?(Numeric) }
           expect(all_numbers).to be true
         end
+      end
+    end
+
+    describe "multiple possible schemas" do
+      let(:schema) do
+        {
+          :"$schema" => "http://json-schema.org/draft-04/schema#",
+          :type      => "object",
+          :oneOf     => [
+            { :"$rel" => "#/definitions/foo" },
+            { :"$rel" => "#/definitions/bar" }
+          ],
+          :definitions => {
+            :foo => {
+              :type => "object",
+              :properties => {
+                :name => { :type => "string", :enum => [ "Foo" ] },
+                :age => { :type => "integer" }
+              }
+            },
+            :bar => {
+              :type => "object",
+              :properties => {
+                :first_name => { :type => "string", :enum => [ "Bar" ] },
+                :last_name => { :type => "string" }
+              }
+            }
+          }
+        }.to_json
+      end
+
+      let(:foo_schema) do
+        {
+          :type => "object",
+          :required => [ "name", "age" ],
+          :properties => {
+            :name => { :type => "string", :enum => [ "Foo" ] },
+            :age => { :type => "integer" }
+          }
+        }.to_json
+      end
+
+      let(:bar_schema) do
+        {
+          :type => "object",
+          :required => [ "first_name", "last_name" ],
+          :properties => {
+            :first_name => { :type => "string", :enum => [ "Bar" ] },
+            :last_name => { :type => "string" }
+          }
+        }
+      end
+
+      it "generates an object" do
+        output = JsonTestData::JsonSchema.new(schema).generate_example
+        expect(JSON.parse(output)).to be_a Hash
+      end
+
+      it "matches one of the given schemas" do
+        output = JsonTestData::JsonSchema.new(schema).generate_example
+        expect(JSON.parse(output)).to match_one_of([foo_schema, bar_schema])
       end
     end
 

--- a/spec/matchers/json_schema_matchers.rb
+++ b/spec/matchers/json_schema_matchers.rb
@@ -1,14 +1,14 @@
 require "rspec/expectations"
 require "json-schema"
 
-RSpec::Matchers.define :match_schema do |schema|
-  match do |output|
-    JSON::Validator.validate(output, schema)
+RSpec::Matchers.define :match_schema do |expected|
+  match do |actual|
+    JSON::Validator.validate(expected, actual)
   end
 end
 
-RSpec::Matchers.define :match_one_of do |schemas|
+RSpec::Matchers.define :match_one_of do |expected|
   match do |actual|
-    JSON::Validator.validate(schemas[0], actual) || JSON::Validator.validate(schemas[1], actual)
+    JSON::Validator.validate(expected[0], actual) || JSON::Validator.validate(expected[1], actual)
   end
 end

--- a/spec/matchers/json_schema_matchers.rb
+++ b/spec/matchers/json_schema_matchers.rb
@@ -1,14 +1,14 @@
 require "rspec/expectations"
 require "json-schema"
 
-RSpec::Matchers.define :match_schema do |expected|
-  match do |actual|
-    JSON::Validator.validate(expected, actual)
+RSpec::Matchers.define :match_schema do |schema|
+  match do |output|
+    JSON::Validator.validate(output, schema)
   end
 end
 
-RSpec::Matchers.define :match_one_of do |expected|
+RSpec::Matchers.define :match_one_of do |schemas|
   match do |actual|
-    JSON::Validator.validate(expected[0], actual) || JSON::Validator.validate(expected[1], actual)
+    JSON::Validator.validate(schemas[0], actual) || JSON::Validator.validate(schemas[1], actual)
   end
 end

--- a/spec/matchers/json_schema_matchers.rb
+++ b/spec/matchers/json_schema_matchers.rb
@@ -6,3 +6,9 @@ RSpec::Matchers.define :match_schema do |expected|
     JSON::Validator.validate(expected, actual)
   end
 end
+
+RSpec::Matchers.define :match_one_of do |expected|
+  match do |actual|
+    JSON::Validator.validate(expected[0], actual) || JSON::Validator.validate(expected[1], actual)
+  end
+end

--- a/spec/matchers/json_schema_matchers.rb
+++ b/spec/matchers/json_schema_matchers.rb
@@ -3,12 +3,12 @@ require "json-schema"
 
 RSpec::Matchers.define :match_schema do |schema|
   match do |actual|
-    JSON::Validator.validate(schema, actual)
+    JSON::Validator.validate!(schema, actual)
   end
 end
 
 RSpec::Matchers.define :match_one_of do |schemas|
   match do |actual|
-    JSON::Validator.validate(schemas[0], actual) || JSON::Validator.validate(schemas[1], actual)
+    JSON::Validator.validate!(schemas[0], actual) || JSON::Validator.validate!(schemas[1], actual)
   end
 end

--- a/spec/matchers/json_schema_matchers.rb
+++ b/spec/matchers/json_schema_matchers.rb
@@ -9,6 +9,6 @@ end
 
 RSpec::Matchers.define :match_one_of do |schemas|
   match do |actual|
-    JSON::Validator.validate!(schemas[0], actual) || JSON::Validator.validate!(schemas[1], actual)
+    JSON::Validator.validate(schemas[0], actual) || JSON::Validator.validate(schemas[1], actual)
   end
 end

--- a/spec/matchers/json_schema_matchers.rb
+++ b/spec/matchers/json_schema_matchers.rb
@@ -1,14 +1,14 @@
 require "rspec/expectations"
 require "json-schema"
 
-RSpec::Matchers.define :match_schema do |expected|
+RSpec::Matchers.define :match_schema do |schema|
   match do |actual|
-    JSON::Validator.validate(expected, actual)
+    JSON::Validator.validate(schema, actual)
   end
 end
 
-RSpec::Matchers.define :match_one_of do |expected|
+RSpec::Matchers.define :match_one_of do |schemas|
   match do |actual|
-    JSON::Validator.validate(expected[0], actual) || JSON::Validator.validate(expected[1], actual)
+    JSON::Validator.validate(schemas[0], actual) || JSON::Validator.validate(schemas[1], actual)
   end
 end

--- a/version.rb
+++ b/version.rb
@@ -1,3 +1,3 @@
 module JsonTestData
-  VERSION = '0.9.0'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
This PR provides for data to be generated using the oneOf property, allowing schemas to have different definitions depending on certain included values.