### PR TITLE
Rework datetimes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json_test_data (1.1.0)
+    json_test_data (1.1.1)
       regexp-examples (~> 1.2)
 
 GEM

--- a/features/string_constraints.feature
+++ b/features/string_constraints.feature
@@ -53,3 +53,20 @@ Feature: String constraints
       """
     When I run the JSON data generator
     Then the output should match the schema
+
+  Scenario: Date-time format
+    Given the following JSON schema:
+      """json
+      {
+        "$schema": "http://json-schema.org/draft-04/schema#",
+        "type": "object",
+        "properties": {
+          "date": {
+            "type": "string",
+            "format": "date-time"
+          }
+        }
+      }
+      """
+      When I run the JSON data generator
+      Then the output should match the schema

--- a/lib/json_test_data/data_structures/string.rb
+++ b/lib/json_test_data/data_structures/string.rb
@@ -4,10 +4,18 @@ module JsonTestData
       def create(schema)
         return schema.fetch(:enum).sample if schema.fetch(:enum, nil)
 
-        pattern(schema).random_example
+        if schema.fetch(:format, nil) == "date-time"
+          generate_date
+        else
+          pattern(schema).random_example
+        end
       end
 
       private
+
+      def generate_date
+        DateTime.new(rand(2000..2100), rand(1..12), rand(1..28),rand(0..23), rand(60), rand(60)).iso8601
+      end
 
       def pattern(schema)
         if schema.fetch(:format, nil)

--- a/lib/json_test_data/data_structures/string.rb
+++ b/lib/json_test_data/data_structures/string.rb
@@ -3,12 +3,9 @@ module JsonTestData
     class << self
       def create(schema)
         return schema.fetch(:enum).sample if schema.fetch(:enum, nil)
+        return generate_date if schema.fetch(:format, nil) == "date-time"
 
-        if schema.fetch(:format, nil) == "date-time"
-          generate_date
-        else
-          pattern(schema).random_example
-        end
+        pattern(schema).random_example
       end
 
       private
@@ -30,7 +27,6 @@ module JsonTestData
 
       def formats
         {
-          "date-time" => /^20\d{2}\-((0[1-9])|(1[0-2]))\-((0[1-9])|([1-2]\d))T(([0-1]\d)|(2[0-3]))\:[0-5]\d\:[0-5]\d(Z|[\+\-]\d{2}\:(0|3)0)$/,
           "email"     => /^\S+@\S+\.\S{1,5}$/,
           "hostname"  => /^[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9]$/,
           "uri"       => /^https?\:\/\/\S{1,10}\.\S{1,10}\.\S{2,5}$/

--- a/version.rb
+++ b/version.rb
@@ -1,3 +1,3 @@
 module JsonTestData
-  VERSION = '1.1.0'
+  VERSION = '1.1.1'
 end


### PR DESCRIPTION
This PR causes actual date-times to be generated and converted to ISO 8601 format, instead of generating strings from regexes. 