### PR TITLE
Use correct namespace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    json_test_data (1.1.1)
+    json_test_data (1.1.2)
       regexp-examples (~> 1.2)
 
 GEM

--- a/lib/json_test_data/data_structures/string.rb
+++ b/lib/json_test_data/data_structures/string.rb
@@ -11,7 +11,7 @@ module JsonTestData
       private
 
       def generate_date
-        DateTime.new(rand(2000..2100), rand(1..12), rand(1..28),rand(0..23), rand(60), rand(60)).iso8601
+        ::DateTime.new(rand(2000..2100), rand(1..12), rand(1..28),rand(0..23), rand(60), rand(60)).iso8601
       end
 
       def pattern(schema)

--- a/version.rb
+++ b/version.rb
@@ -1,3 +1,3 @@
 module JsonTestData
-  VERSION = '1.1.1'
+  VERSION = '1.1.2'
 end


### PR DESCRIPTION
This PR fixes the String module, which previously used `DateTime` where it should have used `::DateTime`.