### PR TITLE
Support passing a handler to generate specific and related data

### DIFF
--- a/fixtures/basic_schema.json
+++ b/fixtures/basic_schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "created_at": {
+      "type": "string",
+      "format": "date-time"
+    },
+    "count": {
+      "type": "number"
+    },
+    "user_count": {
+      "type": "number"
+    }
+  }
+}

--- a/lib/json_test_data.rb
+++ b/lib/json_test_data.rb
@@ -5,7 +5,7 @@ require_relative "./json_test_data/json_schema"
 
 module JsonTestData
   def self.generate!(schema, opts={})
-    schema = JsonSchema.new(schema).generate_example
+    schema = JsonSchema.new(schema, opts[:handler]).generate_example
     opts[:ruby] ? JSON.parse(schema, symbolize_names: true) : schema
   end
 end

--- a/spec/json_test_data/custom_handler_spec.rb
+++ b/spec/json_test_data/custom_handler_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+class FakeHandler
+  def manages_key?(key); end
+  def get_data(key, obj); end
+end
+
+RSpec.describe 'Schema custom handler' do
+  let(:schema) { File.read('./fixtures/basic_schema.json') }
+  let(:result) { JSON.parse(subject.generate_example) }
+
+  subject { JsonTestData::JsonSchema.new(schema, handler) }
+
+  before do
+    allow(JsonTestData::Number).to receive(:create).and_return(9000)
+  end
+
+  describe 'when custom_handler is not passed' do
+    let(:handler) { nil }
+
+    it 'doesnt error' do
+      expect{result}.not_to raise_error
+    end
+
+    it 'still generates data' do
+      expect(result['count']).to eq 9000
+    end
+  end
+
+  describe 'when handler passed' do
+    let(:handler) { FakeHandler.new }
+
+    before do
+      allow(handler).to receive(:manages_key?).and_return(false)
+    end
+
+    context 'and it manages key' do
+      it 'gets data from the handler' do
+        expect(handler).to receive(:manages_key?).with(:count).and_return(true)
+        expect(handler).to receive(:get_data).with(:count, { type: 'number' }).and_return(5555)
+        expect(result['count']).to eq 5555
+      end
+    end
+
+    context "and it doesn't manage key" do
+      it 'returns number test data' do
+        expect(handler).to receive(:manages_key?).with(:count).and_return(false)
+        allow(handler).to receive(:get_data).and_return(5555)
+
+        expect(result['count']).to eq 9000
+        expect(result['user_count']).to eq 9000
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hey @danascheider,

Thanks for the great work on this gem ❤️  - its been a great help getting started to generate test data from json schemas. For our use case we need to ensure that data relating to other models actually exist like user_id on a tasks_list relates to a demo user id that we generated earlier, without needing to hand pick and manage.

Do you think this is a valuable addition to the gem. That others might also find useful ?

This allows passing a custom handler so that you can generate related model data for example a users list and a task list you will want to ensure that the user_id generated in the task list
will exist in the users list and isn't a random number.

Or created_at or updated_at are between certain time ranges - the handler allows you to manage those restraints easily.

Its a basic implementation and defaults the current behaviour if either a handler isn't passed or the handler doesn't manage the key and handler is passed

The handler only needs to expose 2 methods

 - `manages_key?(key)`
 - `get_data(key, obj)`

If it doesn't exist it will exception with NoMethodError as expected - I think this is fine as the user has explicitly passed handler.