### PR TITLE
Fix bug whereby missing type would throw exception key not found.

### DIFF
--- a/lib/json_test_data/json_schema.rb
+++ b/lib/json_test_data/json_schema.rb
@@ -65,7 +65,10 @@ module JsonTestData
 
         if object.has_key?(:properties)
           object.fetch(:properties).each do |k, v|
-            obj[k]  = nil unless v.has_key?(:type)
+            unless v.has_key?(:type)
+              obj[k]  = nil
+              next
+            end
 
             obj[k]  = generate(v)
           end

--- a/spec/json_test_data/json_schema_spec.rb
+++ b/spec/json_test_data/json_schema_spec.rb
@@ -316,11 +316,11 @@ describe JsonTestData::JsonSchema do
     describe 'when type is missing' do
       let(:schema) do
           {
-            '$schema': 'http://json-schema.org/draft-04/schema#',
-            type: 'object',
-            properties: {
-              user: {},
-              title: { type: 'string', enum: [ 'Foobar' ] },
+            :'$schema' => 'http://json-schema.org/draft-04/schema#',
+            :type => 'object',
+            :properties => {
+              :user => {},
+              :title => { :type => 'string', :enum => [ 'Foobar' ] },
             }
           }.to_json
       end

--- a/spec/json_test_data/json_schema_spec.rb
+++ b/spec/json_test_data/json_schema_spec.rb
@@ -312,5 +312,23 @@ describe JsonTestData::JsonSchema do
         end
       end
     end
+
+    describe 'when type is missing' do
+      let(:schema) do
+          {
+            '$schema': 'http://json-schema.org/draft-04/schema#',
+            type: 'object',
+            properties: {
+              user: {},
+              title: { type: 'string', enum: [ 'Foobar' ] },
+            }
+          }.to_json
+      end
+
+      it 'returns nil' do
+        json_schema = JsonTestData::JsonSchema.new(schema)
+        expect(json_schema.generate_example).to eq({ user: nil, title: 'Foobar' }.to_json)
+      end
+    end
   end
 end


### PR DESCRIPTION
Hey @danascheider 

This is a bugfix for when the type key is missing on a property, there already appeared to be code which was doing that check and assigning nil to that key for the object it was building. 

However it didn't prevent it calling generate_data and as the generate_data method was calling obj.fetch(:type) without the second arg, it was causing an exception that the key was not found, this fixes that hopefully and was the original intention of the original code ?